### PR TITLE
permit linting files with spaces in their names

### DIFF
--- a/compiler/vale.vim
+++ b/compiler/vale.vim
@@ -15,7 +15,7 @@ endif
 let s:cpo_save = &cpo
 set cpo&vim
 
-CompilerSet makeprg=vale\ --output\ line\ %
+CompilerSet makeprg=vale\ --output\ line\ %:S
 CompilerSet errorformat=%f:%l:%c:%m
 
 let &cpo = s:cpo_save


### PR DESCRIPTION
best practice would be to drop % all together and allow for make %:S, but likely %:S was intended